### PR TITLE
chore: bump root pnpm to 11.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^5.5.4",
     "vitest": "^4.0.0"
   },
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.1.2",
   "compatiblePackages": {
     "schemaVersion": 1,
     "rollup": {


### PR DESCRIPTION
## Summary
- bump the root `packageManager` pin to `pnpm@11.1.2`
- keep the change scoped to the top-level `package.json` only
- avoid lockfile, workflow, docs, and nested package changes

## Testing
- not run (root packageManager metadata change only)